### PR TITLE
use global offset for buffered chunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,11 @@ function BinarySplit (matcher) {
   matcher = bops.from(matcher || os.EOL)
   var buffered
   var bufcount = 0
+  var offset = 0
   return through(write, end)
 
   function write (buf, enc, done) {
     bufcount++
-    var offset = 0
 
     if (buffered) {
       buf = bops.join([buffered, buf])
@@ -37,6 +37,7 @@ function BinarySplit (matcher) {
       } else {
         if (offset >= buf.length) {
           buffered = undefined
+          offset = 0
         } else {
           buffered = buf
         }


### PR DESCRIPTION
For split matchers that occur rarely in a stream with many chunks, resetting the search offset inside the handler makes for very bad performance (e.g. for a matcher that doesn't occur at all, the runtime is O(N²) where N is the total number of chunks in the stream). Moving the offset outside of the stream-chunk-handler restores linear runtime.
